### PR TITLE
Add ASUS Strix RX580 TOP

### DIFF
--- a/pci_ids.h
+++ b/pci_ids.h
@@ -11,6 +11,7 @@
  */
 static const struct pci_device_id pciidlist[] = {
     {0x1002, 0x67df, 0x1043, 0x0517, 0, 0, CHIP_POLARIS10},     // RX580 (Strix)
+    {0x1002, 0x67df, 0x1043, 0x0519, 0, 0, CHIP_POLARIS10},     // RX580 (Strix TOP)
     {0x1002, 0x687F, 0x1043, 0x0555, 0, 0, CHIP_VEGA10},        // Vega 56 (Strix)
     // {0x1002, 0x731f, 0x1043, 0x04e2, 0, 0, CHIP_NAVI10},     // RX5700XT (Strix)
     {0, 0, 0},


### PR DESCRIPTION
My GPU is an ASUS Strix RX580 TOP.

`lspci -vnn` has its its subsystem ID as 1043:0519 rather than 1043:0517.
```
09:00.0 VGA compatible controller [0300]: Advanced Micro Devices, Inc. [AMD/ATI] Ellesmere [Radeon RX 470/480/570/570X/580/580X/590] [1002:67df] (rev e7) (prog-if 00 [VGA controller])
	Subsystem: ASUSTeK Computer Inc. Ellesmere [Radeon RX 470/480/570/570X/580/580X/590] [1043:0519]
	Flags: bus master, fast devsel, latency 0, IRQ 54
	Memory at e0000000 (64-bit, prefetchable) [size=256M]
	Memory at f0000000 (64-bit, prefetchable) [size=2M]
	I/O ports at d000 [size=256]
	Memory at fce00000 (32-bit, non-prefetchable) [size=256K]
	Expansion ROM at 000c0000 [disabled] [size=128K]
	Capabilities: <access denied>
	Kernel driver in use: amdgpu
	Kernel modules: amdgpu
```

This commit adds this subsystem, and it seems to work with the OpenRGB project.