### PR TITLE
Add support for ROG STRIX-RX480-8G-GAMING

### DIFF
--- a/pci_ids.h
+++ b/pci_ids.h
@@ -10,6 +10,7 @@
     NVIDIA devices already have the adapter loaded.
  */
 static const struct pci_device_id pciidlist[] = {
+    {0x1002, 0x67df, 0x1043, 0x04fd, 0, 0, CHIP_POLARIS10},     // RX480 (Strix)
     {0x1002, 0x67df, 0x1043, 0x0517, 0, 0, CHIP_POLARIS10},     // RX580 (Strix)
     {0x1002, 0x687F, 0x1043, 0x0555, 0, 0, CHIP_VEGA10},        // Vega 56 (Strix)
     // {0x1002, 0x731f, 0x1043, 0x04e2, 0, 0, CHIP_NAVI10},     // RX5700XT (Strix)


### PR DESCRIPTION
RX480 Strix has subsystem `1043:04fd` instead of `1043:0517` for the RX580 Strix. Other than that, it works fine with OpenRGB.

`lspci -vnn` shows:
```
01:00.0 VGA compatible controller [0300]: Advanced Micro Devices, Inc. [AMD/ATI] Ellesmere [Radeon RX 470/480/570/570X/580/580X/590] [1002:67df] (rev c7) (prog-if 00 [VGA controller])
        Subsystem: ASUSTeK Computer Inc. Radeon RX 480 8GB [1043:04fd]
        Flags: bus master, fast devsel, latency 0, IRQ 37
        Memory at 600000000 (64-bit, prefetchable) [size=8G]
        Memory at 500000000 (64-bit, prefetchable) [size=2M]
        I/O ports at e000 [size=256]
        Memory at f7e00000 (32-bit, non-prefetchable) [size=256K]
        Expansion ROM at 000c0000 [disabled] [size=128K]
        Capabilities: [48] Vendor Specific Information: Len=08 <?>
        Capabilities: [50] Power Management version 3
        Capabilities: [58] Express Legacy Endpoint, MSI 00
        Capabilities: [a0] MSI: Enable+ Count=1/1 Maskable- 64bit+
        Capabilities: [100] Vendor Specific Information: ID=0001 Rev=1 Len=010 <?>
        Capabilities: [150] Advanced Error Reporting
        Capabilities: [200] Physical Resizable BAR
        Capabilities: [270] Secondary PCI Express
        Capabilities: [2b0] Address Translation Service (ATS)
        Capabilities: [2c0] Page Request Interface (PRI)
        Capabilities: [2d0] Process Address Space ID (PASID)
        Capabilities: [320] Latency Tolerance Reporting
        Capabilities: [328] Alternative Routing-ID Interpretation (ARI)
        Capabilities: [370] L1 PM Substates
        Kernel driver in use: amdgpu
        Kernel modules: amdgpu
```