### PR TITLE
Add parent PCI device links to i2c device

### DIFF
--- a/aura-gpu-hw.c
+++ b/aura-gpu-hw.c
@@ -411,6 +411,7 @@ static struct hw_i2c_context *aura_gpu_i2c_create (
     context->atom_context->scratch_size_bytes = sizeof(context->scratch);
     context->adapter.owner = THIS_MODULE;
     context->adapter.class = I2C_CLASS_DDC;
+    context->adapter.dev.parent = &pci_dev->dev;
 
     i2c_set_adapdata(&context->adapter, context);
 


### PR DESCRIPTION
Recent OpenRGB (at least v0.7, maybe earlier) check for known PCI parent devices before using i2c devices. aura-gpu did not set the link, thus detection was failing.

**Before**:

My aura device:
```
# i2cdetect -l
i2c-0	i2c       	AMDGPU DM i2c hw bus 0          	I2C adapter
i2c-1	i2c       	AMDGPU DM i2c hw bus 1          	I2C adapter
i2c-2	i2c       	AMDGPU DM i2c hw bus 2          	I2C adapter
i2c-3	i2c       	AMDGPU DM aux hw bus 0          	I2C adapter
i2c-4	smbus     	SMBus I801 adapter at f000      	SMBus adapter
i2c-5	i2c       	AURA GPU adapter                	I2C adapter
```
OpenRGB detection:
```
------------------------------------------------------
|             Detecting I2C interfaces               |
------------------------------------------------------
Registering I2C interface: /dev/i2c-3 Device 0000:0000 Subsystem: 0000:0000
Registering I2C interface: /dev/i2c-1 Device 1002:67FF Subsystem: 1043:04BC
Registering I2C interface: /dev/i2c-4 Device 8086:1C22 Subsystem: 1019:3162
Registering I2C interface: /dev/i2c-2 Device 1002:67FF Subsystem: 1043:04BC
Registering I2C interface: /dev/i2c-0 Device 1002:67FF Subsystem: 1043:04BC
Registering I2C interface: /dev/i2c-5 Device 0000:0000 Subsystem: 0000:0000
------------------------------------------------------
|               Detecting I2C devices                |
------------------------------------------------------
[ASUS Aura GPU] is enabled
[ResourceManager] Calling detection progress callbacks.
[ASUS Aura GPU] Found a device match at Bus 01 for Device 67FF and SubDevice 04BC: ASUS ROG STRIX RX560 Gaming
[ASUS Aura GPU] Test GPU expect: 0x1589 received: 0xFFFF
[ASUS Aura GPU] Found a device match at Bus 03 for Device 67FF and SubDevice 04BC: ASUS ROG STRIX RX560 Gaming
[ASUS Aura GPU] Test GPU expect: 0x1589 received: 0xFFFF
[ASUS Aura GPU] Found a device match at Bus 04 for Device 67FF and SubDevice 04BC: ASUS ROG STRIX RX560 Gaming
[ASUS Aura GPU] Test GPU expect: 0x1589 received: 0xFFFF
[ASUS Aura GPU] no devices found
[ASUS Aura GPU] detection end
```

Please note `0000:0000` for the device `/dev/i2c-5`. It is not known to OpenRGB, thus failing,

**After:**

`i2c-5` properly associated with PCI device and detected correctly:
```
------------------------------------------------------
|             Detecting I2C interfaces               |
------------------------------------------------------
Registering I2C interface: /dev/i2c-3 Device 0000:0000 Subsystem: 0000:0000
Registering I2C interface: /dev/i2c-1 Device 1002:67FF Subsystem: 1043:04BC
Registering I2C interface: /dev/i2c-4 Device 8086:1C22 Subsystem: 1019:3162
Registering I2C interface: /dev/i2c-2 Device 1002:67FF Subsystem: 1043:04BC
Registering I2C interface: /dev/i2c-0 Device 1002:67FF Subsystem: 1043:04BC
Registering I2C interface: /dev/i2c-5 Device 1002:67FF Subsystem: 1043:04BC
------------------------------------------------------
|               Detecting I2C devices                |
------------------------------------------------------
[ASUS Aura GPU] is enabled
[ResourceManager] Calling detection progress callbacks.
[ASUS Aura GPU] Found a device match at Bus 01 for Device 67FF and SubDevice 04BC: ASUS ROG STRIX RX560 Gaming
[ASUS Aura GPU] Test GPU expect: 0x1589 received: 0xFFFF
[ASUS Aura GPU] Found a device match at Bus 03 for Device 67FF and SubDevice 04BC: ASUS ROG STRIX RX560 Gaming
[ASUS Aura GPU] Test GPU expect: 0x1589 received: 0xFFFF
[ASUS Aura GPU] Found a device match at Bus 04 for Device 67FF and SubDevice 04BC: ASUS ROG STRIX RX560 Gaming
[ASUS Aura GPU] Test GPU expect: 0x1589 received: 0xFFFF
[ASUS Aura GPU] Found a device match at Bus 05 for Device 67FF and SubDevice 04BC: ASUS ROG STRIX RX560 Gaming
[ASUS Aura GPU] Test GPU expect: 0x1589 received: 0x1589
[ASUS ROG STRIX RX560 Gaming] Registering RGB controller
[ResourceManager] Calling device list change callbacks.
[ResourceManager] Calling device list change callbacks.
[ASUS Aura GPU] detection end
```

